### PR TITLE
feat: add eslint-plugin-jsdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ export interface ESLintConfigOptions {
   /**
    * Whether to enable [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc) configuration.
    *
-   * @default false
+   * @default true
    */
   jsdoc?: boolean
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ export interface ESLintConfigOptions {
   command?: boolean
 
   /**
+   * Whether to enable [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc) configuration.
+   *
+   * @default false
+   */
+  jsdoc?: boolean
+
+  /**
    * Whether to enable [@eslint-community/eslint-plugin-eslint-comments](https://www.npmjs.com/package/@eslint-community/eslint-plugin-eslint-comments) configuration.
    *
    * @default true

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-antfu": "^3.2.3",
     "eslint-plugin-command": "^4.0.0",
+    "eslint-plugin-jsdoc": "^63.3.3",
     "eslint-plugin-no-only-tests": "^3.4.0",
     "eslint-plugin-package-json": "^1.6.0",
     "eslint-plugin-perfectionist": "^5.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       eslint-plugin-command:
         specifier: ^4.0.0
         version: 4.0.0(@typescript-eslint/typescript-estree@8.63.0)(@typescript-eslint/utils@8.63.0)(eslint@10.7.0)
+      eslint-plugin-jsdoc:
+        specifier: ^63.3.3
+        version: 63.3.3(eslint@10.7.0)
       eslint-plugin-no-only-tests:
         specifier: ^3.4.0
         version: 3.4.0
@@ -179,9 +182,17 @@ packages:
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
+  '@es-joy/jsdoccomment@0.91.0':
+    resolution: {integrity: sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@es-joy/jsdoccomment@0.92.0':
     resolution: {integrity: sha512-WivZqV5jPTYDQJgIMp0hTsyQESKYNY6yCJr4b0l84tYtQntkAMkc6zARh2vlRQyeg4aYHPUkCUDpvr2IWAiGpQ==}
     engines: {node: ^22.22.2 || >=24.15.0}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
 
   '@eslint-community/eslint-plugin-eslint-comments@4.7.2':
     resolution: {integrity: sha512-LF03qURSwEWm2dz5wtdDCzNk+7Opl0X7q6I3undsaIuNsEiNvRV3BCtqu14Q/6Pzg1tBj44LcxpW2EpSLZStZw==}
@@ -793,6 +804,10 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -954,6 +969,10 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1147,6 +1166,12 @@ packages:
       '@typescript-eslint/typescript-estree': '*'
       '@typescript-eslint/utils': '*'
       eslint: '*'
+
+  eslint-plugin-jsdoc@63.3.3:
+    resolution: {integrity: sha512-xI4IeVRzRFA2DGHrPLIxF3U+oJHU3FE+P9Zb27fVs5dPHgfcpoAs0PyCbznVhK7pwR+9BPUztFeXSgpw/CL4Yg==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-no-only-tests@3.4.0:
     resolution: {integrity: sha512-4S3/9Nb7A2tiMcpzEQE9bQSlpeOz6WJkgryBuou/SA8W2x2c8Zf4j0NvTKBjv6qNhF9T79tmkecm/0CHqV0UGg==}
@@ -1383,6 +1408,9 @@ packages:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   identifier-regex@1.1.0:
     resolution: {integrity: sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==}
     engines: {node: '>=18'}
@@ -1435,6 +1463,10 @@ packages:
 
   jsdoc-type-pratt-parser@7.2.0:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
+    engines: {node: '>=20.0.0'}
+
+  jsdoc-type-pratt-parser@8.0.0:
+    resolution: {integrity: sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==}
     engines: {node: '>=20.0.0'}
 
   jsdoc-type-pratt-parser@9.0.0:
@@ -1740,6 +1772,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -1787,6 +1822,12 @@ packages:
   package-json-validator@1.5.2:
     resolution: {integrity: sha512-eHXskJQU4aCiSfjhRfTVtCJ+22/EzLHgYgZv5Gj3teb3NJrnTMzq5BnKAWKvR+PLpknCO1PmOCImDuO+dX4Vaw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1914,6 +1955,9 @@ packages:
   spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
 
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
+
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
@@ -1964,6 +2008,10 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2314,6 +2362,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@es-joy/jsdoccomment@0.91.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.65.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 8.0.0
+
   '@es-joy/jsdoccomment@0.92.0':
     dependencies:
       '@types/estree': 1.0.9
@@ -2321,6 +2377,8 @@ snapshots:
       comment-parser: 1.4.7
       esquery: 1.7.0
       jsdoc-type-pratt-parser: 9.0.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
 
   '@eslint-community/eslint-plugin-eslint-comments@4.7.2(eslint@10.7.0)':
     dependencies:
@@ -2766,6 +2824,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -2990,6 +3050,8 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  are-docs-informative@0.0.2: {}
+
   assertion-error@2.0.1: {}
 
   balanced-match@4.0.4: {}
@@ -3119,6 +3181,26 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
       '@typescript-eslint/utils': 8.63.0(eslint@10.7.0)(typescript@6.0.3)
       eslint: 10.7.0(jiti@2.7.0)
+
+  eslint-plugin-jsdoc@63.3.3(eslint@10.7.0):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.91.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 10.7.0(jiti@2.7.0)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 5.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-no-only-tests@3.4.0: {}
 
@@ -3446,6 +3528,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
 
+  html-entities@2.6.0: {}
+
   identifier-regex@1.1.0:
     dependencies:
       reserved-identifiers: 1.2.0
@@ -3482,6 +3566,8 @@ snapshots:
   js-tokens@4.0.0: {}
 
   jsdoc-type-pratt-parser@7.2.0: {}
+
+  jsdoc-type-pratt-parser@8.0.0: {}
 
   jsdoc-type-pratt-parser@9.0.0:
     dependencies:
@@ -3965,6 +4051,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  object-deep-merge@2.0.1: {}
+
   obug@2.1.3: {}
 
   optionator@0.9.4:
@@ -4067,6 +4155,12 @@ snapshots:
       semver: 7.8.5
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 7.0.2
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   path-exists@4.0.0: {}
 
@@ -4187,6 +4281,11 @@ snapshots:
       spdx-exceptions: 2.5.0
       spdx-license-ids: 3.0.23
 
+  spdx-expression-parse@5.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
   spdx-license-ids@3.0.23: {}
 
   stackback@0.0.2: {}
@@ -4225,6 +4324,11 @@ snapshots:
   tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export async function defineESLintConfig(
     configs.push(...command())
   }
 
+  if (resolvedOptions.jsdoc) {
+    const { jsdoc } = await import('./jsdoc.js')
+    configs.push(...jsdoc())
+  }
+
   if (resolvedOptions.comment) {
     const { comment } = await import('./comment.js')
     configs.push(...comment())

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -7,10 +7,19 @@ import { checkRules } from './test-utils.js'
 test('JSDoc rules should match recommended rules', () => {
   // @keep-sorted
   const disabledRules = [
-    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/implements-on-classes.md
+    'jsdoc/implements-on-classes',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
+    'jsdoc/no-defaults',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-types.md
+    'jsdoc/no-types',
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-jsdoc.md
     'jsdoc/require-jsdoc',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
     'jsdoc/require-param-description',
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-name.md
@@ -18,6 +27,9 @@ test('JSDoc rules should match recommended rules', () => {
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param.md
     'jsdoc/require-param',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property.md
+    'jsdoc/require-property',
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-check.md
     'jsdoc/require-returns-check',
@@ -27,6 +39,9 @@ test('JSDoc rules should match recommended rules', () => {
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns.md
     'jsdoc/require-returns',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields.md
+    'jsdoc/require-yields',
   ]
 
   checkRules({

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -5,11 +5,32 @@ import { jsdocRules } from './jsdoc.js'
 import { checkRules } from './test-utils.js'
 
 test('JSDoc rules should match recommended rules', () => {
+  // @keep-sorted
+  const disabledRules = [
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
+    'jsdoc/require-param-description',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-name.md
+    'jsdoc/require-param-name',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param.md
+    'jsdoc/require-param',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-check.md
+    'jsdoc/require-returns-check',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-description.md
+    'jsdoc/require-returns-description',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns.md
+    'jsdoc/require-returns',
+  ]
+
   checkRules({
     plugin,
     currentRules: jsdocRules,
     recommendedRules: plugin.configs['flat/recommended-typescript'].rules || {},
-    disabledRules: [],
+    disabledRules,
     enabledRules: [],
   })
 })

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -13,9 +13,6 @@ test('JSDoc rules should match recommended rules', () => {
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
     'jsdoc/no-defaults',
 
-    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
-    'jsdoc/tag-lines' ,
-
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-types.md
     'jsdoc/no-types',
 
@@ -45,6 +42,9 @@ test('JSDoc rules should match recommended rules', () => {
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields.md
     'jsdoc/require-yields',
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
+    'jsdoc/tag-lines',
   ]
 
   checkRules({

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -8,6 +8,9 @@ test('JSDoc rules should match recommended rules', () => {
   // @keep-sorted
   const disabledRules = [
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
+
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-jsdoc.md
+    'jsdoc/require-jsdoc',
     'jsdoc/require-param-description',
 
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-name.md

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -13,6 +13,9 @@ test('JSDoc rules should match recommended rules', () => {
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
     'jsdoc/no-defaults',
 
+    // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
+    'jsdoc/tag-lines' ,
+
     // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-types.md
     'jsdoc/no-types',
 

--- a/src/jsdoc.test.ts
+++ b/src/jsdoc.test.ts
@@ -1,0 +1,15 @@
+import plugin from 'eslint-plugin-jsdoc'
+import { test } from 'vitest'
+
+import { jsdocRules } from './jsdoc.js'
+import { checkRules } from './test-utils.js'
+
+test('JSDoc rules should match recommended rules', () => {
+  checkRules({
+    plugin,
+    currentRules: jsdocRules,
+    recommendedRules: plugin.configs['flat/recommended-typescript'].rules || {},
+    disabledRules: [],
+    enabledRules: [],
+  })
+})

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -57,15 +57,6 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-next-type.md
   'jsdoc/require-next-type': 'warn',
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
-  'jsdoc/require-param-description': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-name.md
-  'jsdoc/require-param-name': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param.md
-  'jsdoc/require-param': 'warn',
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property-description.md
   'jsdoc/require-property-description': 'warn',
 
@@ -74,15 +65,6 @@ export const jsdocRules: Linter.RulesRecord = {
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property.md
   'jsdoc/require-property': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-check.md
-  'jsdoc/require-returns-check': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-description.md
-  'jsdoc/require-returns-description': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns.md
-  'jsdoc/require-returns': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-throws-type.md
   'jsdoc/require-throws-type': 'warn',

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -1,0 +1,121 @@
+import type { Linter } from 'eslint'
+import plugin from 'eslint-plugin-jsdoc'
+
+// @keep-sorted
+export const jsdocRules: Linter.RulesRecord = {
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-access.md
+  'jsdoc/check-access': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-alignment.md
+  'jsdoc/check-alignment': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-param-names.md
+  'jsdoc/check-param-names': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-property-names.md
+  'jsdoc/check-property-names': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-tag-names.md
+  'jsdoc/check-tag-names': ['warn', { typed: true }],
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-types.md
+  'jsdoc/check-types': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/check-values.md
+  'jsdoc/check-values': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/empty-tags.md
+  'jsdoc/empty-tags': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/escape-inline-tags.md
+  'jsdoc/escape-inline-tags': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/implements-on-classes.md
+  'jsdoc/implements-on-classes': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/multiline-blocks.md
+  'jsdoc/multiline-blocks': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
+  'jsdoc/no-defaults': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-multi-asterisks.md
+  'jsdoc/no-multi-asterisks': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-types.md
+  'jsdoc/no-types': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/reject-any-type.md
+  'jsdoc/reject-any-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/reject-function-type.md
+  'jsdoc/reject-function-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-jsdoc.md
+  'jsdoc/require-jsdoc': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-next-type.md
+  'jsdoc/require-next-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-description.md
+  'jsdoc/require-param-description': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param-name.md
+  'jsdoc/require-param-name': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-param.md
+  'jsdoc/require-param': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property-description.md
+  'jsdoc/require-property-description': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property-name.md
+  'jsdoc/require-property-name': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property.md
+  'jsdoc/require-property': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-check.md
+  'jsdoc/require-returns-check': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns-description.md
+  'jsdoc/require-returns-description': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-returns.md
+  'jsdoc/require-returns': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-throws-type.md
+  'jsdoc/require-throws-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields-check.md
+  'jsdoc/require-yields-check': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields-type.md
+  'jsdoc/require-yields-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields.md
+  'jsdoc/require-yields': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
+  'jsdoc/tag-lines': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/ts-no-empty-object-type.md
+  'jsdoc/ts-no-empty-object-type': 'warn',
+
+  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/valid-types.md
+  'jsdoc/valid-types': 'warn',
+}
+
+export function jsdoc(): Linter.Config[] {
+  return [
+    {
+      name: 'jsdoc',
+      plugins: {
+        jsdoc: plugin,
+      },
+      rules: {
+        ...jsdocRules,
+      },
+    },
+  ]
+}

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -31,7 +31,7 @@ export const jsdocRules: Linter.RulesRecord = {
   'jsdoc/escape-inline-tags': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/multiline-blocks.md
-  'jsdoc/multiline-blocks': ['warn', {noSingleLineBlocks: true}],
+  'jsdoc/multiline-blocks': ['warn', { noSingleLineBlocks: true }],
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-multi-asterisks.md
   'jsdoc/no-multi-asterisks': 'warn',

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -34,7 +34,7 @@ export const jsdocRules: Linter.RulesRecord = {
   'jsdoc/implements-on-classes': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/multiline-blocks.md
-  'jsdoc/multiline-blocks': 'warn',
+  'jsdoc/multiline-blocks': ['warn', {noSingleLineBlocks: true}],
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
   'jsdoc/no-defaults': 'warn',

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -30,20 +30,11 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/escape-inline-tags.md
   'jsdoc/escape-inline-tags': 'warn',
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/implements-on-classes.md
-  'jsdoc/implements-on-classes': 'warn',
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/multiline-blocks.md
   'jsdoc/multiline-blocks': ['warn', {noSingleLineBlocks: true}],
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-defaults.md
-  'jsdoc/no-defaults': 'warn',
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-multi-asterisks.md
   'jsdoc/no-multi-asterisks': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/no-types.md
-  'jsdoc/no-types': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/reject-any-type.md
   'jsdoc/reject-any-type': 'warn',
@@ -60,9 +51,6 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property-name.md
   'jsdoc/require-property-name': 'warn',
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-property.md
-  'jsdoc/require-property': 'warn',
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-throws-type.md
   'jsdoc/require-throws-type': 'warn',
 
@@ -71,9 +59,6 @@ export const jsdocRules: Linter.RulesRecord = {
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields-type.md
   'jsdoc/require-yields-type': 'warn',
-
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields.md
-  'jsdoc/require-yields': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
   'jsdoc/tag-lines': 'warn',

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -60,8 +60,6 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields-type.md
   'jsdoc/require-yields-type': 'warn',
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/tag-lines.md
-  'jsdoc/tag-lines': 'warn',
 
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/ts-no-empty-object-type.md
   'jsdoc/ts-no-empty-object-type': 'warn',

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -60,7 +60,6 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-yields-type.md
   'jsdoc/require-yields-type': 'warn',
 
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/ts-no-empty-object-type.md
   'jsdoc/ts-no-empty-object-type': 'warn',
 

--- a/src/jsdoc.ts
+++ b/src/jsdoc.ts
@@ -51,9 +51,6 @@ export const jsdocRules: Linter.RulesRecord = {
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/reject-function-type.md
   'jsdoc/reject-function-type': 'warn',
 
-  // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-jsdoc.md
-  'jsdoc/require-jsdoc': 'warn',
-
   // https://github.com/gajus/eslint-plugin-jsdoc/blob/v63.3.3/docs/rules/require-next-type.md
   'jsdoc/require-next-type': 'warn',
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -169,7 +169,7 @@ export interface ReactOptions {
   /**
    * The default files to lint.
    *
-   * @default: All typescript files
+   * @default All typescript files
    *
    * @see {@link Config.files}
    */
@@ -187,7 +187,7 @@ export interface ReactOptions {
   /**
    * React version to use for linting. Set to a semver version like "16.0", "19.2", etc.
    *
-   * @default: '18.0'
+   * @default '18.0'
    */
   version?: string
 }
@@ -204,7 +204,7 @@ export interface VueOptions {
   /**
    * The default files to lint.
    *
-   * @default: All .vue files
+   * @default All .vue files
    *
    * @see {@link Config.files}
    */
@@ -220,7 +220,7 @@ export interface IgnoresOptions {
    * An array of glob patterns indicating the files that the configuration
    * object should not apply to.
    *
-   * @default: some common files to ignore
+   * @default some common files to ignore
    *
    * @see {@link Config.ignores}
    */

--- a/src/options.ts
+++ b/src/options.ts
@@ -76,6 +76,13 @@ export interface ESLintConfigOptions {
   command?: boolean
 
   /**
+   * Whether to enable [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc) configuration.
+   *
+   * @default false
+   */
+  jsdoc?: boolean
+
+  /**
    * Whether to enable [@eslint-community/eslint-plugin-eslint-comments](https://www.npmjs.com/package/@eslint-community/eslint-plugin-eslint-comments) configuration.
    *
    * @default true
@@ -129,6 +136,7 @@ export function resolveOptions({
   vue = false,
   unocss = false,
   command = false,
+  jsdoc = false,
   comment = true,
   ignores = true,
   gitignore = true,
@@ -147,6 +155,7 @@ export function resolveOptions({
     vue,
     unocss,
     command,
+    jsdoc,
     comment,
     ignores,
     gitignore,

--- a/src/options.ts
+++ b/src/options.ts
@@ -78,7 +78,7 @@ export interface ESLintConfigOptions {
   /**
    * Whether to enable [eslint-plugin-jsdoc](https://www.npmjs.com/package/eslint-plugin-jsdoc) configuration.
    *
-   * @default false
+   * @default true
    */
   jsdoc?: boolean
 
@@ -136,7 +136,7 @@ export function resolveOptions({
   vue = false,
   unocss = false,
   command = false,
-  jsdoc = false,
+  jsdoc = true,
   comment = true,
   ignores = true,
   gitignore = true,

--- a/src/typescript.ts
+++ b/src/typescript.ts
@@ -14,12 +14,16 @@ function originalESLintRecommendedRules(): Rules {
   return tseslint.configs.eslintRecommended.rules || {}
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 function eslintRecommendedRules(): Rules {
   return originalESLintRecommendedRules()
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 function originalRecommendedRules(): Rules {
   const configs = [...tseslint.configs.recommended]
   const config = findConfigByName(configs, 'typescript-eslint/recommended')
@@ -29,7 +33,9 @@ function originalRecommendedRules(): Rules {
   return rules
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 function originalRecommendedTypeCheckedOnlyRules(): Rules {
   const configs = [...tseslint.configs.recommendedTypeCheckedOnly]
   const config = findConfigByName(configs, 'typescript-eslint/recommended-type-checked-only')
@@ -48,7 +54,9 @@ function originalStylisticRules(): Rules {
   return rules
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 function recommendedRules(): Rules {
   const rules = originalRecommendedRules()
 
@@ -90,7 +98,9 @@ function recommendedRules(): Rules {
   }
 }
 
-/** @internal */
+/**
+ * @internal
+ */
 function recommendedTypeCheckedOnlyRules(): Rules {
   const rules = originalRecommendedTypeCheckedOnlyRules()
 


### PR DESCRIPTION
## What

Add [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc) as an opt-in config (disabled by default).

-  enables the plugin
- Uses the plugin's `flat/recommended-typescript` rule set (all rules at `warn` level)
- Test verifies the enabled rules stay in sync with the plugin's recommended rules

## Test

```
pnpm vitest run src/jsdoc.test.ts
```
